### PR TITLE
Refactor route table module

### DIFF
--- a/modules/route-table/README.md
+++ b/modules/route-table/README.md
@@ -20,18 +20,20 @@ module "transit_gateway_route_table" {
   name               = "example"
   transit_gateway_id = module.transit_gateway.id
 
-  associations = {
-    vpc1 = {
+  associations = [
+    {
       transit_gateway_attachment_id = module.transit_gateway.vpc_attachments["vpc1"].id
-      propagate_route_table         = true
-    }
-    vpc2 = {
+      replace_existing_association  = true
+    },
+    {
       transit_gateway_attachment_id = module.transit_gateway.vpc_attachments["vpc2"].id
-      propagate_route_table         = true
-    }
-  }
+    },
+  ]
 
-  routes = {
+  propagations = [ module.transit_gateway.vpc_attachments["vpc1"].id, module.transit_gateway.vpc_attachments["vpc2"].id ]
+
+
+  static_routes = {
     blackhole = {
       blackhole              = true
       destination_cidr_block = "0.0.0.0/0"
@@ -93,12 +95,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_associations"></a> [associations](#input\_associations) | A map of transit gateway attachment IDs to associate with the Transit Gateway route table | <pre>map(object({<br/>    transit_gateway_attachment_id = optional(string)<br/>    replace_existing_association  = optional(bool)<br/>    propagate_route_table         = optional(bool, false)<br/>  }))</pre> | `{}` | no |
+| <a name="input_associations"></a> [associations](#input\_associations) | List of Transit Gateway Attachments ids to associate to the route table | <pre>list(object({<br/>    transit_gateway_attachment_id = string<br/>    replace_existing_association  = optional(bool)<br/>  }))</pre> | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls if resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
-| <a name="input_routes"></a> [routes](#input\_routes) | A map of Transit Gateway routes to create in the route table | <pre>map(object({<br/>    destination_cidr_block        = string<br/>    blackhole                     = optional(bool, false)<br/>    transit_gateway_attachment_id = optional(string)<br/>  }))</pre> | `{}` | no |
+| <a name="input_propagations"></a> [propagations](#input\_propagations) | List of Transit Gateway Attachments ids to propagate to the route table | `list(string)` | `[]` | no |
+| <a name="input_static_routes"></a> [static\_routes](#input\_static\_routes) | A map of Transit Gateway routes to create in the route table | <pre>list(object({<br/>    destination_cidr_block        = string<br/>    blackhole                     = optional(bool, false)<br/>    transit_gateway_attachment_id = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | The ID of the EC2 Transit Gateway | `string` | `""` | no |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | The ID of the EC2 Transit Gateway for the route table | `string` | n/a | yes |
 | <a name="input_vpc_routes"></a> [vpc\_routes](#input\_vpc\_routes) | A map of VPC routes to create in the route table provided | <pre>map(object({<br/>    route_table_id              = string<br/>    destination_cidr_block      = optional(string)<br/>    destination_ipv6_cidr_block = optional(string)<br/>  }))</pre> | `{}` | no |
 
 ## Outputs

--- a/modules/route-table/main.tf
+++ b/modules/route-table/main.tf
@@ -14,7 +14,7 @@ resource "aws_ec2_transit_gateway_route_table" "this" {
 }
 
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
-  for_each = { for k, v in var.associations : k => v if var.create }
+  for_each = { for a in var.associations : a.transit_gateway_attachment_id => a if var.create }
 
   transit_gateway_attachment_id  = each.value.transit_gateway_attachment_id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this[0].id
@@ -22,9 +22,9 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
-  for_each = { for k, v in var.associations : k => v if var.create && try(v.propagate_route_table, false) }
+  for_each = { for p in var.propagations : p => p if var.create }
 
-  transit_gateway_attachment_id  = each.value.transit_gateway_attachment_id
+  transit_gateway_attachment_id  = each.value
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this[0].id
 }
 
@@ -33,7 +33,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
 ################################################################################
 
 resource "aws_ec2_transit_gateway_route" "this" {
-  for_each = { for k, v in var.routes : k => v if var.create }
+  for_each = { for route in var.static_routes : route.destination_cidr_block => route if var.create }
 
   destination_cidr_block = each.value.destination_cidr_block
   blackhole              = each.value.blackhole

--- a/modules/route-table/variables.tf
+++ b/modules/route-table/variables.tf
@@ -36,8 +36,8 @@ variable "associations" {
 
 variable "propagations" {
   description = "List of Transit Gateway Attachments ids to propagate to the route table"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 ################################################################################

--- a/modules/route-table/variables.tf
+++ b/modules/route-table/variables.tf
@@ -21,33 +21,37 @@ variable "tags" {
 ################################################################################
 
 variable "transit_gateway_id" {
-  description = "The ID of the EC2 Transit Gateway"
+  description = "The ID of the EC2 Transit Gateway for the route table"
   type        = string
-  default     = ""
 }
 
 variable "associations" {
-  description = "A map of transit gateway attachment IDs to associate with the Transit Gateway route table"
-  type = map(object({
-    transit_gateway_attachment_id = optional(string)
+  description = "List of Transit Gateway Attachments ids to associate to the route table"
+  type = list(object({
+    transit_gateway_attachment_id = string
     replace_existing_association  = optional(bool)
-    propagate_route_table         = optional(bool, false)
   }))
-  default = {}
+  default = []
+}
+
+variable "propagations" {
+  description = "List of Transit Gateway Attachments ids to propagate to the route table"
+  type = list(string)
+  default = []
 }
 
 ################################################################################
 # Route(s)
 ################################################################################
 
-variable "routes" {
+variable "static_routes" {
   description = "A map of Transit Gateway routes to create in the route table"
-  type = map(object({
+  type = list(object({
     destination_cidr_block        = string
     blackhole                     = optional(bool, false)
     transit_gateway_attachment_id = optional(string)
   }))
-  default = {}
+  default = []
 }
 
 variable "vpc_routes" {


### PR DESCRIPTION
- Decouple route table associations from propagations. An attachment can be associated to a single route table but propagated to multiple route tables. Having separate variables for both allows managing them separately. Reference [here](https://docs.aws.amazon.com/vpc/latest/tgw/how-transit-gateways-work.html#tgw-route-table-association-overview).

- Also changed the definition of the `associations` and `propagations` variable to list instead of map for a cleaner definition. The attachment-id is used as the key in the for_each to prevent recreation.

- Renamed `routes` to `static_routes`. AWS refers to these as _Static Routes_ in their [documentation](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-create-static-route.html) so just trying to use the same terminology. Also changed the variable from a map to a list and used the `destination_cidr_block` as the key for the for_each since every route requires a destination_cidr_block and it can't be duplicated. I believe this makes it easier to define than trying to figure out a name for each route to use as a key.